### PR TITLE
Rollout restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ In order to interact with the MoJ Cloud Platform there are certain environment v
 - SERVICE_ACCOUNT
 - SSH_FILE_FOR_SECRETS
 
-These can be obtained by having the necessary permissions to (interact with Cloud Platform)[https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#how-to-use-kubectl-to-connect-to-the-cluster].
+These can be obtained by having the necessary permissions to [interact with Cloud Platform](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#how-to-use-kubectl-to-connect-to-the-cluster).
 
 `SSH_FILE_FOR_SECRETS` is required by repos that make use of git-crypt in order to hold their secrets. Currently that is all of them except `fb-av`.
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -29,6 +29,8 @@ encoded_git_crypt_key=$ENCODED_GIT_CRYPT_KEY
 
 credential_name="${service_account}_${platform_environment}_${deployment_environment}"
 
+pod_name=${application_name}-${platform_environment}-${deployment_environment}
+
 echo -n ${k8s_cluster_cert} | base64 -d > ./ca.crt
 kubectl config set-cluster ${k8s_cluster_name} --certificate-authority=./ca.crt --server=https://api.${k8s_cluster_name}
 
@@ -90,7 +92,12 @@ echo $helm_command
 echo "Writing ${environment_full_name} config to $config_file"
 $helm_command > $config_file
 
+echo "Applying configuration"
 kubectl apply -f $config_file -n "${namespace}"
 
-# echo "Restarting pods"
-# kubectl -n ${namespace} rollout restart deployment
+echo "Rolling out and restarting pods"
+kubectl -n ${namespace} rollout restart deployment ${pod_name}
+
+kubectl -n ${namespace} rollout status deployment ${pod_name}
+
+echo "Successfully rolled out and restarted pods"


### PR DESCRIPTION
We want to know when the pods have successfully deployed and restarted. This will be especially important when we come to trigger the acceptance tests.

https://trello.com/c/l4kw5212/846-baseline-deploy-check-when-deployment-is-done-so-we-can-run-tests

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>