### PR TITLE
Check correct container image is used

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -100,4 +100,15 @@ kubectl -n ${namespace} rollout restart deployment ${pod_name}
 
 kubectl -n ${namespace} rollout status deployment ${pod_name}
 
-echo "Successfully rolled out and restarted pods"
+echo "Checking correct image was deployed"
+images=$(kubectl get pods -n ${namespace} -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | sort | uniq)
+
+for image in ${images}; do
+  if [[ $image == *$build_SHA* ]]; then
+    echo "Successfully rolled out and restarted ${pod_name} pods in ${namespace}"
+    exit 0
+  fi
+done
+
+echo "Unable to find image using ${build_SHA}"
+exit 1


### PR DESCRIPTION
We want to make sure that the correct image that was tagged in the build step is being used when the pods are rolled out and restarted.