### PR TITLE
Use single submitter repo again

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -29,10 +29,6 @@ echo "Finding right ecr repos from ${k8s_namespace}"
 ecr_credentials=$(kubectl get secrets -n formbuilder-repos)
 
 for ecr_credential in ${ecr_credentials[@]}; do
-  if [[ ${ecr_credential} = "ecr-repo-fb-submitter-worker" ]]; then
-    continue
-  fi
-
   if [[ ${ecr_credential} == *"${ecr_credentials_secret}"* ]]; then
     echo "Getting secrets from AWS"
     export AWS_DEFAULT_REGION=eu-west-2

--- a/bin/deploy
+++ b/bin/deploy
@@ -104,10 +104,6 @@ kubectl apply -f $config_file -n "${namespace}"
 current_images=$(kubectl get pods -n ${namespace} -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | sort | uniq)
 
 for current_image in ${current_images}; do
-  if [[ ${current_image} == *"/fb-submitter-worker:"* ]]; then
-    continue
-  fi
-
   if [[ $current_image == *$application_name* ]]; then
     image_deployed=false
     pod_prefix=$(echo ${current_image} | awk -F'formbuilder/' '{print $NF}' | cut -f1 -d":")


### PR DESCRIPTION
We no longer need to cater for 2 submitter repos as the pluralised version is the now the one in use