### PR TITLE
Retrieve CirclCI API token from K8S secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ In order to interact with the MoJ Cloud Platform there are certain environment v
 - K8S_TOKEN_TEST_PRODUCTION
 - K8S_TOKEN_LIVE_DEV
 - K8S_TOKEN_LIVE_PRODUCTION
-- SERVICE_ACCOUNT
 - SSH_FILE_FOR_SECRETS
 
 These can be obtained by having the necessary permissions to [interact with Cloud Platform](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/getting-started/kubectl-config.html#how-to-use-kubectl-to-connect-to-the-cluster).

--- a/bin/acceptance_tests
+++ b/bin/acceptance_tests
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -e -u -o pipefail
 
-circle_token=$CIRCLE_TOKEN
+source "$(dirname "$0")/set_k8s_context"
+
+circle_token=$(kubectl get secrets -n formbuilder-repos circleci-api-token -o jsonpath="{.data.token}" | base64 -d)
 
 # Trigger new pipeline
 #

--- a/bin/acceptance_tests
+++ b/bin/acceptance_tests
@@ -3,6 +3,10 @@ set -e -u -o pipefail
 
 source "$(dirname "$0")/set_k8s_context"
 
+k8s_token=$(echo $K8S_TOKEN | base64 -d)
+service_account=$SERVICE_ACCOUNT
+
+set_context "${service_account}" "formbuilder-repos" ${k8s_token}
 circle_token=$(kubectl get secrets -n formbuilder-repos circleci-api-token -o jsonpath="{.data.token}" | base64 -d)
 
 # Trigger new pipeline

--- a/bin/acceptance_tests
+++ b/bin/acceptance_tests
@@ -4,9 +4,8 @@ set -e -u -o pipefail
 source "$(dirname "$0")/set_k8s_context"
 
 k8s_token=$(echo $K8S_TOKEN | base64 -d)
-service_account=$SERVICE_ACCOUNT
 
-set_context "${service_account}" "formbuilder-repos" ${k8s_token}
+set_context "circleci" "formbuilder-repos" ${k8s_token}
 circle_token=$(kubectl get secrets -n formbuilder-repos circleci-api-token -o jsonpath="{.data.token}" | base64 -d)
 
 # Trigger new pipeline

--- a/bin/build
+++ b/bin/build
@@ -3,6 +3,9 @@ set -e -u -o pipefail
 
 source "$(dirname "$0")/set_k8s_context"
 
+k8s_token=$(echo $K8S_TOKEN | base64 -d)
+k8s_namespace=formbuilder-repos
+
 ecr_credentials_secret=$ECR_CREDENTIALS_SECRET
 
 environment_name=$ENVIRONMENT_NAME
@@ -11,11 +14,13 @@ build_SHA=$BUILD_SHA
 echo "build and push docker images"
 echo "SHA is ${build_SHA}"
 
+set_context "circleci" ${k8s_namespace} ${k8s_token}
+
 echo "Getting ECR credentials"
 ecr_username=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_username}" | base64 -d)
 ecr_password=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_password}" | base64 -d)
 
-echo "Finding right ecr repos from formbuilder-repos namespace"
+echo "Finding right ecr repos from ${k8s_namespace}"
 ecr_credentials=$(kubectl get secrets -n formbuilder-repos)
 
 for ecr_credential in ${ecr_credentials[@]}; do

--- a/bin/build
+++ b/bin/build
@@ -1,11 +1,7 @@
 #!/bin/bash
 set -e -u -o pipefail
 
-k8s_cluster_cert=$K8S_CLUSTER_CERT
-k8s_cluster_name=$K8S_CLUSTER_NAME
-k8s_token=$(echo $K8S_TOKEN | base64 -d)
-k8s_namespace=formbuilder-repos
-service_account=$SERVICE_ACCOUNT
+source "$(dirname "$0")/set_k8s_context"
 
 ecr_credentials_secret=$ECR_CREDENTIALS_SECRET
 
@@ -15,17 +11,11 @@ build_SHA=$BUILD_SHA
 echo "build and push docker images"
 echo "SHA is ${build_SHA}"
 
-echo -n ${k8s_cluster_cert} | base64 -d > ./ca.crt
-kubectl config set-cluster ${k8s_cluster_name} --certificate-authority=./ca.crt --server=https://api.${k8s_cluster_name}
-kubectl config set-credentials ${service_account} --token=${k8s_token}
-kubectl config set-context ${service_account} --cluster=${k8s_cluster_name} --user=${service_account} --namespace=${k8s_namespace}
-kubectl config use-context ${service_account}
-
 echo "Getting ECR credentials"
 ecr_username=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_username}" | base64 -d)
 ecr_password=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_password}" | base64 -d)
 
-echo "Finding right ecr repos from ${k8s_namespace}"
+echo "Finding right ecr repos from formbuilder-repos namespace"
 ecr_credentials=$(kubectl get secrets -n formbuilder-repos)
 
 for ecr_credential in ${ecr_credentials[@]}; do

--- a/bin/deploy
+++ b/bin/deploy
@@ -28,9 +28,6 @@ k8s_token_env_var_name="K8S_TOKEN_${k8s_environment_name}"
 k8s_token=$(eval "echo \${$k8s_token_env_var_name}" | base64 -d)
 
 build_SHA=$BUILD_SHA
-k8s_cluster_cert=$K8S_CLUSTER_CERT
-k8s_cluster_name=$K8S_CLUSTER_NAME
-service_account=$SERVICE_ACCOUNT
 application_name=$APPLICATION_NAME
 namespace=$K8S_NAMESPACE
 
@@ -43,17 +40,7 @@ credential_name="${service_account}_$(echo ${environment_full_name} | tr '-' '_'
 ## Begin setting kubernetes context
 ################################################################
 
-echo -n ${k8s_cluster_cert} | base64 -d > ./ca.crt
-kubectl config set-cluster ${k8s_cluster_name} --certificate-authority=./ca.crt --server=https://api.${k8s_cluster_name}
-
-echo "kubectl configure credentials"
-kubectl config set-credentials "${credential_name}" --token="${k8s_token}"
-
-echo "kubectl configure context"
-kubectl config set-context "${credential_name}" --cluster="${k8s_cluster_name}" --user="${credential_name}" --namespace="${namespace}"
-
-echo "kubectl use circleci context"
-kubectl config use-context $credential_name
+set_context "${credential_name}" "${namespace}" ${k8s_token}
 
 echo "apply kubernetes changes to ${platform_environment} ${deployment_environment}"
 

--- a/bin/deploy
+++ b/bin/deploy
@@ -34,7 +34,7 @@ namespace=$K8S_NAMESPACE
 ssh_file_for_secrets=$SSH_FILE_FOR_SECRETS
 encoded_git_crypt_key=$ENCODED_GIT_CRYPT_KEY
 
-credential_name="${service_account}_$(echo ${environment_full_name} | tr '-' '_')"
+credential_name="circleci_$(echo ${environment_full_name} | tr '-' '_')"
 
 ################################################################
 ## Begin setting kubernetes context

--- a/bin/deploy
+++ b/bin/deploy
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -e -u -o pipefail
 
+source "$(dirname "$0")/set_k8s_context"
+
 get_images() {
   kubectl get pods -n "$1" -o jsonpath="{..image}" | tr -s '[[:space:]]' '\n' | sort | uniq
 }

--- a/bin/get_environment_variables
+++ b/bin/get_environment_variables
@@ -18,8 +18,6 @@ echo "Set these environment variables in your CI"
 echo
 echo "K8S_CLUSTER_NAME=live-1.cloud-platform.service.justice.gov.uk"
 echo
-echo "SERVICE_ACCOUNT=circleci"
-echo
 echo "K8S_CLUSTER_CERT=${cert}"
 echo
 echo "K8S_TOKEN=${token}"

--- a/bin/get_environment_variables
+++ b/bin/get_environment_variables
@@ -92,4 +92,4 @@ echo "CircleCI docs: https://circleci.com/docs/2.0/add-ssh-key/"
 echo "Github docs: https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-github-deploy-key"
 echo
 
-echo "ENCODED_GIT_CRYPT_KEY=No idea how to find"
+echo "ENCODED_GIT_CRYPT_KEY needs to be exported from the app specific secrets repo. Follow the instructions found in the Runbook"

--- a/bin/set_k8s_context
+++ b/bin/set_k8s_context
@@ -3,14 +3,22 @@ set -e -u -o pipefail
 
 k8s_cluster_cert=$K8S_CLUSTER_CERT
 k8s_cluster_name=$K8S_CLUSTER_NAME
-k8s_token=$(echo $K8S_TOKEN | base64 -d)
-k8s_namespace=formbuilder-repos
-service_account=$SERVICE_ACCOUNT
 
-echo "Setting K8S context for formbuilder-repos namespace"
+# $1 user or account
+# $2 namespace
+# $3 token related to the namespace
+set_context() {
+  echo "Setting K8S context for ${1} user in ${2} namespace"
 
-echo -n ${k8s_cluster_cert} | base64 -d > ./ca.crt
-kubectl config set-cluster ${k8s_cluster_name} --certificate-authority=./ca.crt --server=https://api.${k8s_cluster_name}
-kubectl config set-credentials ${service_account} --token=${k8s_token}
-kubectl config set-context ${service_account} --cluster=${k8s_cluster_name} --user=${service_account} --namespace=${k8s_namespace}
-kubectl config use-context ${service_account}
+  echo -n ${k8s_cluster_cert} | base64 -d > ./ca.crt
+  kubectl config set-cluster ${k8s_cluster_name} --certificate-authority=./ca.crt --server=https://api.${k8s_cluster_name}
+
+  echo "kubectl configure credentials"
+  kubectl config set-credentials ${1} --token=${3}
+
+  echo "kubectl configure context"
+  kubectl config set-context ${1} --cluster=${k8s_cluster_name} --user=${1} --namespace=${2}
+
+  echo "kubectl use circleci context"
+  kubectl config use-context ${1}
+}

--- a/bin/set_k8s_context
+++ b/bin/set_k8s_context
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -e -u -o pipefail
+
+k8s_cluster_cert=$K8S_CLUSTER_CERT
+k8s_cluster_name=$K8S_CLUSTER_NAME
+k8s_token=$(echo $K8S_TOKEN | base64 -d)
+k8s_namespace=formbuilder-repos
+service_account=$SERVICE_ACCOUNT
+
+echo "Setting K8S context for formbuilder-repos namespace"
+
+echo -n ${k8s_cluster_cert} | base64 -d > ./ca.crt
+kubectl config set-cluster ${k8s_cluster_name} --certificate-authority=./ca.crt --server=https://api.${k8s_cluster_name}
+kubectl config set-credentials ${service_account} --token=${k8s_token}
+kubectl config set-context ${service_account} --cluster=${k8s_cluster_name} --user=${service_account} --namespace=${k8s_namespace}
+kubectl config use-context ${service_account}


### PR DESCRIPTION
We cannot find how to access the CircleCI API token except by doing something very naughty.

Since not everyone is comfortable being naughty let's use a K8S secret that can be accessed by the fb-deploy scripts in order to get the CIRCLE_TOKEN instead of having to set it as an environment variable in every pipeline.

As we are going to be setting the K8S context for the formbuilder-repos namespace twice, pull that out into its' own script and source it when required.
