### PR TITLE
Use deployment name instead of image name

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -111,31 +111,37 @@ kubectl apply -f $config_file -n "${namespace}"
 # Begin rollout and restart
 ################################################################
 
+deployments=$(kubectl get deployments -n ${namespace})
+
 for current_image in ${current_images}; do
   if [[ $current_image == *$application_name* ]]; then
     image_deployed=false
-    pod_prefix=$(echo ${current_image} | awk -F'formbuilder/' '{print $NF}' | cut -f1 -d":")
-    pod_name=${pod_prefix}-${environment_full_name}
-    current_SHA=${current_image##*:}
+    app_image_name=$(echo ${current_image} | awk -F'formbuilder/' '{print $NF}' | cut -f1 -d":")
 
-    # If the current SHA and the build SHA are the same then it is a redeployment
-    # of the last commit and kubectl apply will not restart the pods.
-    # In this instance we need to call rollout restart
-    if [[ $current_SHA = $build_SHA ]]; then
-      echo "Current SHA and the build SHA are the same"
-      echo "Rolling out and restarting pods for ${pod_name}"
-      kubectl -n ${namespace} rollout restart deployment ${pod_name}
-    fi
+    for deployment in ${deployments}; do
+      if [[ $deployment == *$app_image_name* ]]; then
+        current_SHA=${current_image##*:}
 
-    kubectl -n ${namespace} rollout status deployment ${pod_name}
+        # If the current SHA and the build SHA are the same then it is a redeployment
+        # of the last commit and kubectl apply will not restart the pods.
+        # In this instance we need to call rollout restart
+        if [[ $current_SHA = $build_SHA ]]; then
+          echo "Current SHA and the build SHA are the same"
+          echo "Rolling out and restarting pods for ${deployment}"
+          kubectl -n ${namespace} rollout restart deployment ${deployment}
+        fi
 
-    echo "Checking correct image was deployed with sha: ${build_SHA}"
-    new_images=$(get_images "${namespace}")
+        kubectl -n ${namespace} rollout status deployment ${deployment}
 
-    for image in ${new_images}; do
-      if [[ $image == *$build_SHA* ]]; then
-        echo "Successfully rolled out and restarted ${pod_name} pods in ${namespace}"
-        image_deployed=true
+        echo "Checking correct image was deployed with sha: ${build_SHA}"
+        new_images=$(get_images "${namespace}")
+
+        for image in ${new_images}; do
+          if [[ $image == *$build_SHA* ]]; then
+            echo "Successfully rolled out and restarted ${deployment} pods in ${namespace}"
+            image_deployed=true
+          fi
+        done
       fi
     done
 


### PR DESCRIPTION
Some of our apps have inconsistencies between the name of the images that are deployed and the name of the deployments within kubernetes config.

Instead of taking the name of the image, get the name of the deployment and match using that so that rollout, restart and status can be used with the correct parameter.