### PR TITLE
Adjust acceptance tests script

### DIFF
--- a/bin/acceptance_tests
+++ b/bin/acceptance_tests
@@ -1,52 +1,16 @@
 #!/bin/bash
 set -e -u -o pipefail
 
-source "$(dirname "$0")/set_k8s_context"
+echo 'Cloning acceptance tests'
+git clone https://github.com/ministryofjustice/fb-acceptance-tests
 
-k8s_token=$(echo $K8S_TOKEN | base64 -d)
+cd fb-acceptance-tests
 
-set_context "circleci" "formbuilder-repos" ${k8s_token}
-circle_token=$(kubectl get secrets -n formbuilder-repos circleci-api-token -o jsonpath="{.data.token}" | base64 -d)
+echo 'Installing dependencies'
+bundle install
 
-# Trigger new pipeline
-#
-results=$(curl -u ${circle_token}: -X POST https://circleci.com/api/v2/project/github/ministryofjustice/fb-acceptance-tests/pipeline \
-   -H 'Content-Type: application/json' -H 'Accept: application/json')
+echo 'Setting up acceptance tests'
+make setup-ci -s # -s hides environment variables in log output
 
-pipeline_id=$(echo "$results" | jq --raw-output '.id')
-pipeline_number=$(echo "$results" | jq --raw-output '.number')
-
-## Retry for 22 minutes (maximum time of the slowest acceptance test)
-##
-retries=132
-sleeping_time=10
-
-for (( i = 0; i < retries; i++ )); do
-  echo "=================================================================="
-  workflow_results=$(curl -X GET "https://circleci.com/api/v2/pipeline/${pipeline_id}/workflow" \
-    -H 'Accept: application/json' \
-    -H "Circle-Token: ${circle_token}")
-
-  workflow_id=$(echo "$workflow_results" | jq --raw-output '.items[0].id')
-  workflow_state=$(echo "$workflow_results" | jq --raw-output '.items[0].status')
-
-  circle_link="https://app.circleci.com/pipelines/github/ministryofjustice/fb-acceptance-tests/${pipeline_number}/workflows/${workflow_id}"
-
-  echo
-  echo "Pipeline '${circle_link}' is ${workflow_state}."
-
-  if [[ $workflow_state == 'success' ]]; then
-    echo "Acceptance tests successfully completed."
-    exit 0
-  fi
-
-  if [[ $workflow_state == 'failed' ]]; then
-    echo "Acceptance tests failed."
-    exit 1
-  fi
-
-  sleep $sleeping_time
-done
-
-echo "Unable to determine what happened with the pipeline"
-exit 1
+echo 'Running acceptance tests'
+make spec-ci

--- a/bin/get_environment_variables
+++ b/bin/get_environment_variables
@@ -101,3 +101,14 @@ echo "Github docs: https://circleci.com/docs/2.0/gh-bb-integration/#creating-a-g
 echo
 
 echo "ENCODED_GIT_CRYPT_KEY needs to be exported from the app specific secrets repo. Follow the instructions found in the Runbook"
+
+echo
+echo "For repos that require acceptance tests:"
+
+client_id=$(kubectl get secrets -n formbuilder-repos google-credentials -o json | jq -r '.data["client_id"]' | base64 -D)
+client_secret=$(kubectl get secrets -n formbuilder-repos google-credentials -o json | jq -r '.data["client_secret"]' | base64 -D)
+refresh_token=$(kubectl get secrets -n formbuilder-repos google-credentials -o json | jq -r '.data["refresh_token"]' | base64 -D)
+echo "GOOGLE_CLIENT_ID=${client_id}"
+echo "GOOGLE_CLIENT_SECRET=${client_secret}"
+echo "GOOGLE_REFRESH_TOKEN=${refresh_token}"
+echo


### PR DESCRIPTION
We want the acceptance tests to run as part of an app deployment instead of using the circle API to trigger a job and then wait for it to finish.

https://trello.com/c/BxIV1rkx/931-make-acceptance-tests-run-inside-each-deployment