### PR TITLE
Add smoke tests script

### DIFF
--- a/bin/get_environment_variables
+++ b/bin/get_environment_variables
@@ -135,3 +135,10 @@ echo
 slack_webhook=$(kubectl get secrets -n formbuilder-repos slack-webhooks -o json | jq -r '.data["deployments"]' | base64 -D)
 echo "SLACK_WEBHOOK=${slack_webhook}"
 echo
+
+smoke_test_user=$(kubectl get secrets -n formbuilder-repos smoke-test-form -o jsonpath={.data.smoke_test_user} | base64 -D)
+smoke_test_password=$(kubectl get secrets -n formbuilder-repos smoke-test-form -o jsonpath={.data.smoke_test_password} | base64 -D)
+echo "SMOKE_TEST_USER=${smoke_test_user}"
+echo "SMOKE_TEST_PASSWORD=${smoke_test_password}"
+echo
+echo

--- a/bin/set_up_acceptance_tests
+++ b/bin/set_up_acceptance_tests
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e -u -o pipefail
+
+echo 'Cloning acceptance tests'
+git clone https://github.com/ministryofjustice/fb-acceptance-tests
+
+cd fb-acceptance-tests
+
+echo 'Installing dependencies'
+bundle install
+
+echo 'Setting up acceptance tests'
+make setup-ci -s # -s hides environment variables in log output
+

--- a/bin/smoke_tests
+++ b/bin/smoke_tests
@@ -3,5 +3,5 @@ set -e -u -o pipefail
 
 source "$(dirname "$0")/set_up_acceptance_tests"
 
-echo 'Running acceptance tests'
-make spec-ci
+echo 'Running smoke tests'
+make smoke-tests


### PR DESCRIPTION
## Context

This script will clone the acceptance test and run the smoke test. The work can be followed (still about to finish here) https://github.com/ministryofjustice/fb-acceptance-tests/compare/add-smoke-tests?expand=1

## Needs to complete

- [x] See about the basic auth secret (add to k8s secrets and the get environment vars script)
