### PR TITLE
Make sure smoke tests hides env vars

### DIFF
--- a/bin/set_up_acceptance_tests
+++ b/bin/set_up_acceptance_tests
@@ -11,4 +11,3 @@ bundle install
 
 echo 'Setting up acceptance tests'
 make setup-ci -s # -s hides environment variables in log output
-

--- a/bin/smoke_tests
+++ b/bin/smoke_tests
@@ -4,4 +4,4 @@ set -e -u -o pipefail
 source "$(dirname "$0")/set_up_acceptance_tests"
 
 echo 'Running smoke tests'
-make smoke-tests
+make smoke-tests -s # -s hides environment variables in log output


### PR DESCRIPTION
The smoke-test task move the env vars to the container, so we need to use the -s option