### PR TITLE
Do not build images if they already exist

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -3,6 +3,35 @@ set -e -u -o pipefail
 
 source "$(dirname "$0")/set_k8s_context"
 
+# $1 repository name
+# $2 image tag
+skip_build_and_push() {
+  # Returns a "An error occurred (ImageNotFoundException)" if image doesn't exist and a non zero code
+  aws ecr describe-images --repository-name "$1" --image-ids imageTag="$2" >> /dev/null
+
+  if [[ $? == 0 ]]; then
+    echo "Image with $2 already exists in $1"
+    echo "Not building or pushing a new image"
+  else
+    return 1
+  fi
+}
+
+# $1 ECR repo URL
+# $2 environment name
+# $3 Image tag
+# $4 Dockerfile path
+build_and_push() {
+  echo "Building image for environment $2 and build SHA $3..."
+  docker build -t "$1:latest-$2" -t "$1:$3" -f "$4" .
+
+  echo "Pushing image for latest-$2"
+  docker push "$1:latest-$2"
+
+  echo "Pushing build SHA $3 image..."
+  docker push "$1:$3"
+}
+
 k8s_token=$(echo $K8S_TOKEN | base64 -d)
 k8s_namespace=formbuilder-repos
 
@@ -25,16 +54,6 @@ ecr_credentials=$(kubectl get secrets -n formbuilder-repos)
 
 for ecr_credential in ${ecr_credentials[@]}; do
   if [[ ${ecr_credential} == *"${ecr_credentials_secret}"* ]]; then
-    echo "Getting secrets from AWS"
-    export AWS_DEFAULT_REGION=eu-west-2
-    export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
-    export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
-    export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)
-
-    echo 'Logging into AWS ECR...'
-    aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
-
-    echo  'Building docker image...'
     ecr_credential_match="${ecr_credentials_secret}-"
     application_type=${ecr_credential#"$ecr_credential_match"}
 
@@ -51,13 +70,18 @@ for ecr_credential in ${ecr_credentials[@]}; do
     fi
 
     if [[ -f $dockerfile ]]; then
-      docker build -t ${ECR_REPO_URL}:latest-${environment_name} -t ${ECR_REPO_URL}:${build_SHA} -f ${dockerfile} .
+      echo "Getting secrets from AWS"
+      export AWS_DEFAULT_REGION=eu-west-2
+      export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
+      export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
+      export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)
 
-      echo 'Pushing latest docker image...'
-      docker push ${ECR_REPO_URL}:latest-${environment_name}
+      echo 'Logging into AWS ECR...'
+      aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
 
-      echo 'Pushing current build SHA docker image...'
-      docker push ${ECR_REPO_URL}:${build_SHA}
+      repo_name=${ECR_REPO_URL#*/}
+      skip_build_and_push ${repo_name} ${build_SHA} || \
+        build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
     else
       echo "Dockerfile ${dockerfile} not found! :("
     fi


### PR DESCRIPTION
This is potentially a controversial PR.

For each ECR repo we are always building and pushing images even if they have already been built and push. We can speed up two different parts of the deployment if we check for an images existence first:

1. When deploying to Live. The same image tagged with the build SHA is used in both Test and Live.
2. Whenever we re run a deployment pipeline without any code changes.

Using `aws ecr describe-images` will look up the metadata for that particular image. If it doesn't exist then returns an error message and a non zero exit code (255 I think). If that happens then we know to build the image. However if the command actually returns some metadata then it's already been built before so we can skip building and pushing and allow the deploy step to restart the pods which will grab the already existing image with the existing build SHA.

Doing the above means that we can knock off a few minutes (between 2 and 4 for the submitter) for first time deployments of a code change, and then for re runs it saves a lot more.

Finally we also move the authentication with the apps ECR repo to later in the loop as we only want to do this if an actual Dockerfile exists.