### PR TITLE
Acceptance tests private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Build and Deployment scripts for From Builder platform and services.
 
 In order to interact with the MoJ Cloud Platform there are certain environment variables that need to be set in the pipelines:
 
+- ACCEPTANCE_TESTS_PRIVATE_KEY
 - AWS_BUILD_IMAGE_ECR_ACCOUNT_URL
 - AWS_BUILD_IMAGE_ACCESS_KEY_ID
 - AWS_BUILD_IMAGE_SECRET_ACCESS_KEY

--- a/bin/get_environment_variables
+++ b/bin/get_environment_variables
@@ -127,9 +127,11 @@ echo "For repos that require acceptance tests:"
 client_id=$(kubectl get secrets -n formbuilder-repos google-credentials -o json | jq -r '.data["client_id"]' | base64 -D)
 client_secret=$(kubectl get secrets -n formbuilder-repos google-credentials -o json | jq -r '.data["client_secret"]' | base64 -D)
 refresh_token=$(kubectl get secrets -n formbuilder-repos google-credentials -o json | jq -r '.data["refresh_token"]' | base64 -D)
+acceptance_tests_private_key=$(kubectl get configmaps -n formbuilder-saas-test fb-acceptance-tests-config-map -o json | jq -r '.data["ENCODED_PRIVATE_KEY"]')
 echo "GOOGLE_CLIENT_ID=${client_id}"
 echo "GOOGLE_CLIENT_SECRET=${client_secret}"
 echo "GOOGLE_REFRESH_TOKEN=${refresh_token}"
+echo "ACCEPTANCE_TESTS_PRIVATE_KEY=${acceptance_tests_private_key}"
 echo
 
 slack_webhook=$(kubectl get secrets -n formbuilder-repos slack-webhooks -o json | jq -r '.data["deployments"]' | base64 -D)


### PR DESCRIPTION
We will be signing future acceptance tests requests to the Metadata API using a private key so it it needs to be set in the environment for any deployment job that is going to run them

https://trello.com/c/YHZR7f31/1012-acceptance-tests-for-api-metadata