### PR TITLE
Do not skip the build and push stage for live environments

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -79,9 +79,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
       echo 'Logging into AWS ECR...'
       aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
 
-      repo_name=${ECR_REPO_URL#*/}
-      skip_build_and_push ${repo_name} ${build_SHA} || \
-        build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
+      build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
     else
       echo "Dockerfile ${dockerfile} not found! :("
     fi


### PR DESCRIPTION
The skip mechanism was there in order to stop building the image twice if the SHA is the same. This is because test-dev, test-production use the same container just with different tags: latest-test and latest-live.

However the skip is checking whether the SHA exists, which it will do because it just built it for latest-test and then skipping tagging for latest-live.

This will unfortunately mean we will always be building the image twice, at least for now.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>