### PR TITLE
Remove bundle install

### DIFF
--- a/bin/set_up_acceptance_tests
+++ b/bin/set_up_acceptance_tests
@@ -6,8 +6,5 @@ git clone https://github.com/ministryofjustice/fb-acceptance-tests
 
 cd fb-acceptance-tests
 
-echo 'Installing dependencies'
-bundle install
-
 echo 'Setting up acceptance tests'
 make setup-ci -s # -s hides environment variables in log output


### PR DESCRIPTION
It is not needed to instal gems on CircleCI container.