### PR TITLE
Deploy testable branches for the editor app

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -29,20 +29,33 @@ skip_build_and_push() {
 # $3 Image tag
 # $4 Dockerfile path
 build_and_push() {
+  if [[ $branch_name == testable-* ]]; then
+    echo "*******************************************************************"
+    echo "${branch_name} is a testable branch. Not building or pushing $1:latest-$2"
+    echo "*******************************************************************"
+    echo
+  else
+    echo "*******************************************************************"
+    echo "Building image for environment $2"
+    docker build -t "$1:latest-$2" -f "$4" .
+    echo "*******************************************************************"
+    echo
+
+    echo "*******************************************************************"
+    echo "Pushing image for latest-$2"
+    docker push "$1:latest-$2"
+    echo "*******************************************************************"
+    echo
+  fi
+
   echo "*******************************************************************"
-  echo "Building image for environment $2 and build SHA $3..."
-  docker build -t "$1:latest-$2" -t "$1:$3" -f "$4" .
+  echo "Building image for build SHA $3"
+  docker build -t "$1:$3" -f "$4" .
   echo "*******************************************************************"
   echo
 
   echo "*******************************************************************"
-  echo "Pushing image for latest-$2"
-  docker push "$1:latest-$2"
-  echo "*******************************************************************"
-  echo
-
-  echo "*******************************************************************"
-  echo "Pushing build SHA $3 image..."
+  echo "Pushing build SHA $3 image"
   docker push "$1:$3"
   echo "*******************************************************************"
   echo
@@ -53,12 +66,21 @@ k8s_namespace=formbuilder-repos
 
 ecr_credentials_secret=$ECR_CREDENTIALS_SECRET
 
+echo "*******************************************************************"
 environment_name=$ENVIRONMENT_NAME
-build_SHA=$BUILD_SHA
+echo "environment_name is ${environment_name}"
+echo "*******************************************************************"
+echo
 
 echo "*******************************************************************"
-echo "build and push docker images"
-echo "SHA is ${build_SHA}"
+build_SHA=$BUILD_SHA
+echo "build_SHA is ${build_SHA}"
+echo "*******************************************************************"
+echo
+
+echo "*******************************************************************"
+branch_name=$CIRCLE_BRANCH
+echo "branch_name is ${branch_name}"
 echo "*******************************************************************"
 echo
 
@@ -79,9 +101,11 @@ echo
 
 for ecr_credential in ${ecr_credentials[@]}; do
   if [[ ${ecr_credential} == *"${ecr_credentials_secret}"* ]]; then
+    # Despite this saying it is a secret and/or credential, this is in fact just
+    # the name of an ECR repository for an app. Unfortunate naming
     echo "*******************************************************************"
+    echo "ECR repo ${ecr_credential} matched"
     ecr_credential_match="${ecr_credentials_secret}-"
-    echo "ECR repo matched ${ecr_credential_match}"
     echo "*******************************************************************"
     echo
 
@@ -109,6 +133,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
       echo "*******************************************************************"
       echo
 
+      echo "*******************************************************************"
       echo "Getting secrets from AWS"
       export AWS_DEFAULT_REGION=eu-west-2
       export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)

--- a/bin/build
+++ b/bin/build
@@ -3,62 +3,44 @@ set -e -u -o pipefail
 
 source "$(dirname "$0")/set_k8s_context"
 
-# $1 repository name
-# $2 image tag
-skip_build_and_push() {
-  # Returns a "An error occurred (ImageNotFoundException)" if image doesn't exist and a non zero code
-  aws ecr describe-images --repository-name "$1" --image-ids imageTag="$2" >> /dev/null
-
-  if [[ $? == 0 ]]; then
-    echo "*******************************************************************"
-    echo "Image with $2 already exists in $1"
-    echo "Not building or pushing a new image"
-    echo "*******************************************************************"
-    echo
-  else
-    echo "*******************************************************************"
-    echo "Image $2 does not exist. Will build"
-    echo "*******************************************************************"
-    echo
-    return 1
-  fi
-}
-
 # $1 ECR repo URL
 # $2 environment name
 # $3 Image tag
 # $4 Dockerfile path
 build_and_push() {
-  if [[ $branch_name == testable-* ]]; then
+  echo "*******************************************************************"
+  repo_name=${1#*/}
+  echo "repo_name is ${repo_name}"
+  echo "*******************************************************************"
+  echo
+
+  if [[ $repo_name == *fb-runner* ]]; then
+    # The fb-runner and fb-runner-node use the latest-test and latest-live tags
+    # The other apps make use of the build SHA as the tag
     echo "*******************************************************************"
-    echo "${branch_name} is a testable branch. Not building or pushing $1:latest-$2"
-    echo "*******************************************************************"
-    echo
-  else
-    echo "*******************************************************************"
-    echo "Building image for environment $2"
+    echo "Runner app. Building ${repo_name}:latest-$2"
     docker build -t "$1:latest-$2" -f "$4" .
     echo "*******************************************************************"
     echo
 
     echo "*******************************************************************"
-    echo "Pushing image for latest-$2"
+    echo "Pushing image for ${repo_name}:latest-$2"
     docker push "$1:latest-$2"
     echo "*******************************************************************"
     echo
+  else
+    echo "*******************************************************************"
+    echo "Building image for build SHA $3"
+    docker build -t "$1:$3" -f "$4" .
+    echo "*******************************************************************"
+    echo
+
+    echo "*******************************************************************"
+    echo "Pushing build SHA $3 image"
+    docker push "$1:$3"
+    echo "*******************************************************************"
+    echo
   fi
-
-  echo "*******************************************************************"
-  echo "Building image for build SHA $3"
-  docker build -t "$1:$3" -f "$4" .
-  echo "*******************************************************************"
-  echo
-
-  echo "*******************************************************************"
-  echo "Pushing build SHA $3 image"
-  docker push "$1:$3"
-  echo "*******************************************************************"
-  echo
 }
 
 k8s_token=$(echo $K8S_TOKEN | base64 -d)

--- a/bin/deploy
+++ b/bin/deploy
@@ -41,6 +41,12 @@ echo "build_SHA is ${build_SHA}"
 echo "*******************************************************************"
 echo
 
+branch_name=$CIRCLE_BRANCH
+echo "*******************************************************************"
+echo "branch name is ${branch_name}"
+echo "*******************************************************************"
+echo
+
 echo "*******************************************************************"
 application_name=$APPLICATION_NAME
 echo "application_name is ${application_name}"
@@ -125,8 +131,39 @@ else
 fi
 
 echo "*******************************************************************"
-echo "Setting helm_command"
-helm_command="helm template deploy/${chartname} $helm_command --set circleSha1=${build_SHA} --set environmentName=${environment_full_name} --set platformEnv=${platform_environment}"
+if [[ $branch_name == testable-* ]] && [[ $application_name == 'fb-editor' ]]; then
+  # editor_host is an environment variable that is set in the secrets for the fb-editor
+  # In order to get authentication to work correctly the editor_host needs to be
+  # overridden to include the name of the branch which will become the host
+  # Passing editor_host into the helm command will override the editor_host
+  # that is set in the secrets for the editor
+  editor_host="${branch_name}.apps.live-1.cloud-platform.service.justice.gov.uk"
+  echo "Testable branch. Setting editor_host to ${editor_host}"
+
+  # Also set app_name to be the name of the branch
+  echo "Setting app_name to ${branch_name}"
+
+  helm_command="helm template deploy/${chartname} $helm_command --set circleSha1=${build_SHA} \
+  --set environmentName=${environment_full_name} --set platformEnv=${platform_environment} \
+  --set editor_host=${editor_host} --set app_name=${branch_name}"
+else
+  echo "Standard deployment branch"
+
+  # Currently only the editor will make use of the environment variable app_name
+  # when doing a standard deployment
+  # Should another app in the future require testable branches to be built then
+  # they can potentially use the same mechanism the editor does
+  echo "Setting app_name to ${application_name}"
+
+  helm_command="helm template deploy/${chartname} $helm_command --set circleSha1=${build_SHA} \
+  --set environmentName=${environment_full_name} --set platformEnv=${platform_environment} \
+  --set app_name=${application_name}"
+fi
+echo "*******************************************************************"
+echo
+
+echo "*******************************************************************"
+echo "Full helm command"
 echo $helm_command
 echo "*******************************************************************"
 echo
@@ -165,8 +202,24 @@ for current_image in ${current_images}; do
     echo "*******************************************************************"
     echo
 
+    echo "*******************************************************************"
+    if [[ $branch_name == testable-* ]] && [[ $application_name == 'fb-editor' ]]; then
+      echo "Setting deployment_to_match to ${branch_name}"
+      deployment_to_match=$branch_name
+    else
+      echo "Setting deployment_to_match to ${app_image_name}"
+      deployment_to_match=$app_image_name
+    fi
+    echo "*******************************************************************"
+    echo
+
     for deployment in ${deployments}; do
-      if [[ $deployment == *$app_image_name* ]]; then
+      if [[ $deployment == *$deployment_to_match* ]]; then
+        echo "*******************************************************************"
+        echo "matched deployment with ${deployment}"
+        echo "*******************************************************************"
+        echo
+
         echo "*******************************************************************"
         current_SHA=${current_image##*:}
         echo "current_SHA is ${current_SHA}"

--- a/bin/deploy
+++ b/bin/deploy
@@ -229,7 +229,7 @@ for current_image in ${current_images}; do
         # If the current SHA and the build SHA are the same then it is a redeployment
         # of the last commit and kubectl apply will not restart the pods.
         # In this instance we need to call rollout restart
-        if [[ $current_SHA = $build_SHA ]]; then
+        if [[ $current_SHA == $build_SHA ]]; then
           echo "*******************************************************************"
           echo "Current SHA and the build SHA are the same"
           echo "Rolling out and restarting pods for ${deployment}"


### PR DESCRIPTION
This creates the ability to trigger deployment of specific branches for
the editor app for any github branch that has been prepended with
'testabe-'.

This means that developers can deploy out specific changes for the
editor and they can be tested independently of each other.

This process relies very heavily on two environment variables being set:

- editor_host
- app_name

The editor_host is set as a secret in the fb-editor-deploy repo, with
different values for Test and Live. This needs to be overridden in any
deployable branch to include the branch name. It is the thing that makes
the authentication mechanism work correctly. The editor app is the only
app that makes use of this environment variable presently. All other
apps will ignore the value set when a standard deployment is triggered.

The app_name is used to set the hostname for the app which Kubernetes
will use to create the necessary ingress rules as well as deployment
configuration.

We change the build script so that it will only tag an image with
'latest-test' or 'latest-live' if the app being deployed is one of the
runner apps, i.e fb-runner or fb-runner-node. Both of those apps do not
make use of the SHA as they are 'published' by the editor and publisher
apps respectively. The editor and the publisher are not able to see the
SHA which relatest the latest git commit as these are only available in
the CircleCI pipeline. As a result of this the editor and publisher need
to use an image which has been built and tagged with 'latest-test' or
'latest-live'.

If the app being deployed is not a runner type then the SHA relating to
the triggering git commit will be used as the image tag.