### PR TITLE
Do not build if image already exists

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -29,17 +29,29 @@ build_and_push() {
     echo "*******************************************************************"
     echo
   else
-    echo "*******************************************************************"
-    echo "Building image for build SHA $3"
-    docker build -t "$1:$3" -f "$4" .
-    echo "*******************************************************************"
-    echo
+    # Returns a "An error occurred (ImageNotFoundException)" if image doesn't
+    # exist and a non zero code
+    aws ecr describe-images --repository-name "$repo_name" --image-ids imageTag="$3" >> /dev/null
 
-    echo "*******************************************************************"
-    echo "Pushing build SHA $3 image"
-    docker push "$1:$3"
-    echo "*******************************************************************"
-    echo
+    if [[ $? == 0 ]]; then
+      echo "*******************************************************************"
+      echo "Image with $3 already exists in ${repo_name}"
+      echo "Not building or pushing a new image"
+      echo "*******************************************************************"
+      echo
+    else
+      echo "*******************************************************************"
+      echo "Building image for build SHA $3"
+      docker build -t "$1:$3" -f "$4" .
+      echo "*******************************************************************"
+      echo
+
+      echo "*******************************************************************"
+      echo "Pushing build SHA $3 image"
+      docker push "$1:$3"
+      echo "*******************************************************************"
+      echo
+    fi
   fi
 }
 


### PR DESCRIPTION
During the build step for deployments we check whether the app being built is a the runner or the runner-node. If it is then the image gets tagged with `latest-test` or `latest-live`.

However for all other apps we use the commit sha as the tag for the image. Build and deployment to Test always happens before the Live environment therefore the image for any given app has already been built and pushed to the ECR repo.

There is no need to rebuild that image again as it already exists so here we check for whether it already exists and if it does then we skip the build and push. This is fine as we do not want another image tag going out to production other than the one that was tagged in the Test step of the build process.

For the runner and runner-node it will always build and push.
