### PR TITLE
Correctly handle the AWS CLI response from ECR

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -4,6 +4,47 @@ set -e -u -o pipefail
 source "$(dirname "$0")/set_k8s_context"
 
 # $1 ECR repo URL
+# $2 Image tag
+skip_build_and_push() {
+  echo "*******************************************************************"
+  # Returns a "An error occurred (ImageNotFoundException)" if image doesn't
+  # exist and a non zero code
+  echo "If there is a 'An error occurred (ImageNotFoundException)' outputted"
+  echo "in the logs this is ok as it is a potential expected response from AWS"
+  echo "if the an image with $2 tag does NOT exist"
+  echo "*******************************************************************"
+  echo
+
+  aws ecr describe-images --repository-name "$1" --image-ids imageTag="$2" >> /dev/null
+  if [[ $? == 0 ]]; then
+    echo "*******************************************************************"
+    echo "Image with $2 already exists in $1"
+    echo "Not building or pushing a new image"
+    echo "*******************************************************************"
+    echo
+  else
+    return 1
+  fi
+}
+
+# $1 ECR repo URL
+# $2 Image tag
+# $3 Dockerfile path
+build_and_push_sha_image() {
+  echo "*******************************************************************"
+  echo "Building image for build SHA $2"
+  docker build -t "$1:$2" -f "$3" .
+  echo "*******************************************************************"
+  echo
+
+  echo "*******************************************************************"
+  echo "Pushing build SHA $2 image"
+  docker push "$1:$2"
+  echo "*******************************************************************"
+  echo
+}
+
+# $1 ECR repo URL
 # $2 environment name
 # $3 Image tag
 # $4 Dockerfile path
@@ -29,29 +70,7 @@ build_and_push() {
     echo "*******************************************************************"
     echo
   else
-    # Returns a "An error occurred (ImageNotFoundException)" if image doesn't
-    # exist and a non zero code
-    aws ecr describe-images --repository-name "$repo_name" --image-ids imageTag="$3" >> /dev/null
-
-    if [[ $? == 0 ]]; then
-      echo "*******************************************************************"
-      echo "Image with $3 already exists in ${repo_name}"
-      echo "Not building or pushing a new image"
-      echo "*******************************************************************"
-      echo
-    else
-      echo "*******************************************************************"
-      echo "Building image for build SHA $3"
-      docker build -t "$1:$3" -f "$4" .
-      echo "*******************************************************************"
-      echo
-
-      echo "*******************************************************************"
-      echo "Pushing build SHA $3 image"
-      docker push "$1:$3"
-      echo "*******************************************************************"
-      echo
-    fi
+    skip_build_and_push $repo_name $3 || build_and_push_sha_image $1 $3 $4
   fi
 }
 


### PR DESCRIPTION
Calling `aws cli describe-images` will return an error response if the
image does not exist. Because we set `-e` in the build script file this
means that the script will exit at that point.

What we want is to check whether the response returned a metadata
string, which it will if the image requested exists, or whether it
raised an error.

If the latter then the only way to avoid the script exiting is to use
`||` and run `build_and_push_sha_image` instead.