### PR TITLE
Build specific images base on application type

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -141,27 +141,36 @@ for ecr_credential in ${ecr_credentials[@]}; do
     fi
 
     if [[ -f $dockerfile ]]; then
-      echo "*******************************************************************"
-      echo "Using Dockerfile from ${dockerfile}"
-      echo "*******************************************************************"
-      echo
+      # continue build if it is an app without a type. i.e it has no workers
+      # e.g the datastore or the filestore
+      # or
+      # continue build if the deployment config injected an image_type into
+      # the environment, such as api, web, worker or workers. yes we have both singular and plural :(
+      # also the image_type is the same as the application_type found found above
+      # otherwise skip the build
+      if [[ -z "$IMAGE_TYPE" ]] || [[ -n "$IMAGE_TYPE" && "$IMAGE_TYPE" == "$application_type" ]]; then
+        echo "*******************************************************************"
+        echo "Using Dockerfile from ${dockerfile}"
+        echo "*******************************************************************"
+        echo
 
-      echo "*******************************************************************"
-      echo "Getting secrets from AWS"
-      export AWS_DEFAULT_REGION=eu-west-2
-      export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
-      export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
-      export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)
-      echo "*******************************************************************"
-      echo
+        echo "*******************************************************************"
+        echo "Getting secrets from AWS"
+        export AWS_DEFAULT_REGION=eu-west-2
+        export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
+        export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
+        export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)
+        echo "*******************************************************************"
+        echo
 
-      echo "*******************************************************************"
-      echo 'Logging into AWS ECR'
-      aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
-      echo "*******************************************************************"
-      echo
+        echo "*******************************************************************"
+        echo 'Logging into AWS ECR'
+        aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
+        echo "*******************************************************************"
+        echo
 
-      build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
+        build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
+      fi
     else
       echo "*******************************************************************"
       echo "Dockerfile ${dockerfile} not found! :("


### PR DESCRIPTION
Some of our applications have two types. They are usually a web version
and a worker version, but sometimes they are an api type.

This change provides the ability to have the option for deployment
pipelines to be configured to build both the types in parallel. This is
done by setting an environment variable called IMAGE_TYPE to whatever
type you want to build in a given step.

If no IMAGE_TYPE is set then the script will build the application in
the normal way.