### PR TITLE
Handle unbound variable correctly

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -148,7 +148,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
       # the environment, such as api, web, worker or workers. yes we have both singular and plural :(
       # also the image_type is the same as the application_type found found above
       # otherwise skip the build
-      if [[ -z "$IMAGE_TYPE" ]] || [[ -n "$IMAGE_TYPE" && "$IMAGE_TYPE" == "$application_type" ]]; then
+      if [[ -z "${IMAGE_TYPE-}" ]] || [[ -n "$IMAGE_TYPE" && "$IMAGE_TYPE" == "$application_type" ]]; then
         echo "*******************************************************************"
         echo "Using Dockerfile from ${dockerfile}"
         echo "*******************************************************************"


### PR DESCRIPTION
The IMAGE_TYPE variable may or may not be set. It depends on which app
is being deployed.

In order to avoid the unbound variable error being thrown as a result of
the `-u` setting in the script we have to add a `-` when checking the
variable exists. Bash will then be able to handle if the variable has
not been set to a value.