### PR TITLE
Set context for the saas namespace

### DIFF
--- a/bin/set_testable_editors_context
+++ b/bin/set_testable_editors_context
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e -u -o pipefail
+
+source "$(dirname "$0")/set_k8s_context"
+
+k8s_token=$(echo $K8S_SAAS_TOKEN | base64 -d)
+k8s_namespace=formbuilder-saas-test
+
+set_context "circleci" "${k8s_namespace}" "${k8s_token}"


### PR DESCRIPTION
The job to tear down the testable editors that have been merged into
main requires setting the context for the circleci kubernetes user to be
that of formbuilder-saas-test namespace. This means using the token
specific to that namespace instead of the formbuilder-repos token.