### PR TITLE
Target specific runner apps when restarting

### DIFF
--- a/bin/restart_all_pods
+++ b/bin/restart_all_pods
@@ -9,6 +9,16 @@ deployment_environment=${DEPLOYMENT_ENV}
 environment_full_name="${platform_environment}-${deployment_environment}"
 credential_name="circleci_${environment_full_name}"
 
+if [[ -z "${RUNNER_TYPE-}" ]]; then
+  echo "*******************************************************************"
+  echo 'RUNNER_TYPE has not been set. This needs to be either fb-runner or fb-runner-node'
+  echo "*******************************************************************"
+  echo
+  exit 1
+fi
+
+runner_type=$RUNNER_TYPE
+
 ## Concatenate K8S_TOKEN_TEST_DEV for example
 ##
 k8s_environment_name=$(echo ${environment_full_name} | tr '-' '_' | tr [a-z] [A-Z]})
@@ -17,19 +27,48 @@ k8s_token=$(eval "echo \${$k8s_token_env_var_name}" | base64 -d)
 
 set_context "${credential_name}" "${k8s_namespace}" ${k8s_token}
 
-echo "*******************************************************************"
-echo "Rolling out and restarting pods for ${k8s_namespace}"
-kubectl rollout restart deployments -n ${k8s_namespace}
-echo "*******************************************************************"
-echo
+to_deploy=()
+deployments=$(kubectl get deployments -n ${k8s_namespace} | awk {'print $1'})
+for deployment in ${deployments}; do
+  # first column title which we do not want
+  if [[ $deployment == 'NAME' ]]; then
+    continue
+  fi
 
-echo "*******************************************************************"
-echo "Checking rollout status"
-kubectl get deploy --output name -n ${k8s_namespace} | xargs -n1 -t kubectl rollout status -n "${k8s_namespace}"
-echo "*******************************************************************"
-echo
+  image=$(kubectl get deployments ${deployment} -n ${k8s_namespace} -o jsonpath={..'image'})
+  if [[ $image == *${runner_type}:latest-${platform_environment}* ]]; then
+    echo "*******************************************************************"
+    echo "Will restart deployment for ${deployment}"
+    to_deploy+=(${deployment})
+    echo "*******************************************************************"
+    echo
+  fi
+done
 
-echo "*******************************************************************"
-echo "Rollout and restart completed"
-echo "*******************************************************************"
-echo
+if [ ${#to_deploy[@]} -eq 0 ]; then
+  echo "*******************************************************************"
+  echo "No deployments found with image containing ${runner_type}"
+  echo "*******************************************************************"
+  echo
+else
+  echo "*******************************************************************"
+  echo "Rolling out and restarting ${runner_type} pods for ${k8s_namespace}"
+  rolled_out=$(kubectl rollout restart deployments -n ${k8s_namespace} ${to_deploy[*]})
+  echo "*******************************************************************"
+  echo
+
+  echo "*******************************************************************"
+  echo "Checking rollout status"
+  # The response from kubectl contains the word 'restarted' which rollout status will
+  # not recognise, so remove it. There may well be other response keywords that
+  # kubectl returns which we can add if needs be. kubectl will not action any deployment
+  # it does not recognise and will just log an error
+  printf '%s\n' "${rolled_out//restarted/}" | xargs -n1 -t kubectl rollout status -n "${k8s_namespace}"
+  echo "*******************************************************************"
+  echo
+
+  echo "*******************************************************************"
+  echo "Rollout and restart completed"
+  echo "*******************************************************************"
+  echo
+fi


### PR DESCRIPTION
Adjust the restart script so that it looks for apps specific to the type
of runner that is being deployed.

Requires the environment variable RUNNER_TYPE to be set in the
environment to be either fb-runner or fb-runner-node.

When calling rollout restart kubectl will return a string of the
deployment it restarted along with a response keyword such as
'restarted'. We need to filter these out when checking on the rollout
status for a deployment. There may well be other keywords we should
filter out in the future.