### PR TITLE
Publisher bearer token

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -157,6 +157,13 @@ fi
 echo "*******************************************************************"
 echo
 
+if [[ $application_name == 'fb-publisher' ]]; then
+  # The clusters (K8S and EKS) have different names for their bearer tokens
+  # So these tokens have been set in the deployment pipeline
+  bearer_token=$K8S_BEARER_TOKEN
+  helm_command="${helm_command} --set bearer_token=${bearer_token}"
+fi
+
 echo "*******************************************************************"
 echo "Full helm command"
 echo $helm_command

--- a/bin/deploy
+++ b/bin/deploy
@@ -164,6 +164,7 @@ if [[ $application_name == 'fb-publisher' ]]; then
   # it needs this dynamic grep for K8S_BEARER_TOKEN_TEST and
   # K8S_BEARER_TOKEN_LIVE
   bearer_token_env_var_name="K8S_BEARER_TOKEN_${platform_environment}"
+  bearer_token_env_var_name=$(echo $bearer_token_env_var_name | tr '-' '_' | tr [a-z] [A-Z])
   bearer_token=$(eval "echo \${$bearer_token_env_var_name}")
   helm_command="${helm_command} --set bearer_token=${bearer_token}"
 fi

--- a/bin/deploy
+++ b/bin/deploy
@@ -164,7 +164,7 @@ if [[ $application_name == 'fb-publisher' ]]; then
   # it needs this dynamic grep for K8S_BEARER_TOKEN_TEST and
   # K8S_BEARER_TOKEN_LIVE
   bearer_token_env_var_name="K8S_BEARER_TOKEN_${platform_environment}"
-  bearer_token_env_var_name=$(echo $bearer_token_env_var_name | tr '-' '_' | tr [a-z] [A-Z])
+  bearer_token_env_var_name=$(echo $bearer_token_env_var_name | tr [a-z] [A-Z])
   bearer_token=$(eval "echo \${$bearer_token_env_var_name}")
   helm_command="${helm_command} --set bearer_token=${bearer_token}"
 fi

--- a/bin/deploy
+++ b/bin/deploy
@@ -160,7 +160,11 @@ echo
 if [[ $application_name == 'fb-publisher' ]]; then
   # The clusters (K8S and EKS) have different names for their bearer tokens
   # So these tokens have been set in the deployment pipeline
-  bearer_token=$K8S_BEARER_TOKEN
+  # Each token is different also per environment (test and live) so
+  # it needs this dynamic grep for K8S_BEARER_TOKEN_TEST and
+  # K8S_BEARER_TOKEN_LIVE
+  bearer_token_env_var_name="K8S_BEARER_TOKEN_${platform_environment}"
+  bearer_token=$(eval "echo \${$bearer_token_env_var_name}")
   helm_command="${helm_command} --set bearer_token=${bearer_token}"
 fi
 

--- a/bin/deploy-eks
+++ b/bin/deploy-eks
@@ -160,7 +160,11 @@ echo
 if [[ $application_name == 'fb-publisher' ]]; then
   # The clusters (K8S and EKS) have different names for their bearer tokens
   # So these tokens have been set in the deployment pipeline
-  bearer_token=$EKS_BEARER_TOKEN
+  # Each token is different also per environment (test and live) so
+  # it needs this dynamic echo for EKS_BEARER_TOKEN_TEST and
+  # EKS_BEARER_TOKEN_LIVE
+  bearer_token_env_var_name="EKS_BEARER_TOKEN_${platform_environment}"
+  bearer_token=$(eval "echo \${$bearer_token_env_var_name}")
   helm_command="${helm_command} --set bearer_token=${bearer_token}"
 fi
 

--- a/bin/deploy-eks
+++ b/bin/deploy-eks
@@ -157,6 +157,13 @@ fi
 echo "*******************************************************************"
 echo
 
+if [[ $application_name == 'fb-publisher' ]]; then
+  # The clusters (K8S and EKS) have different names for their bearer tokens
+  # So these tokens have been set in the deployment pipeline
+  bearer_token=$EKS_BEARER_TOKEN
+  helm_command="${helm_command} --set bearer_token=${bearer_token}"
+fi
+
 echo "*******************************************************************"
 echo "Full helm command"
 echo $helm_command

--- a/bin/deploy-eks
+++ b/bin/deploy-eks
@@ -164,6 +164,7 @@ if [[ $application_name == 'fb-publisher' ]]; then
   # it needs this dynamic echo for EKS_BEARER_TOKEN_TEST and
   # EKS_BEARER_TOKEN_LIVE
   bearer_token_env_var_name="EKS_BEARER_TOKEN_${platform_environment}"
+  bearer_token_env_var_name=$(echo $bearer_token_env_var_name | tr '-' '_' | tr [a-z] [A-Z])
   bearer_token=$(eval "echo \${$bearer_token_env_var_name}")
   helm_command="${helm_command} --set bearer_token=${bearer_token}"
 fi

--- a/bin/deploy-eks
+++ b/bin/deploy-eks
@@ -164,7 +164,7 @@ if [[ $application_name == 'fb-publisher' ]]; then
   # it needs this dynamic echo for EKS_BEARER_TOKEN_TEST and
   # EKS_BEARER_TOKEN_LIVE
   bearer_token_env_var_name="EKS_BEARER_TOKEN_${platform_environment}"
-  bearer_token_env_var_name=$(echo $bearer_token_env_var_name | tr '-' '_' | tr [a-z] [A-Z])
+  bearer_token_env_var_name=$(echo $bearer_token_env_var_name | tr [a-z] [A-Z])
   bearer_token=$(eval "echo \${$bearer_token_env_var_name}")
   helm_command="${helm_command} --set bearer_token=${bearer_token}"
 fi


### PR DESCRIPTION
Since the bearer tokens are have different names in the two different clusters (K8S and EKS), we need a way to be able to choose the correct token respective of the cluster we are deploying to.

Co-authored-by: Tomas Destefi <tomas.destefi@digital.justice.gov.uk>
Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>