### PR TITLE
Service token cache bearer token

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -169,6 +169,18 @@ if [[ $application_name == 'fb-publisher' ]]; then
   helm_command="${helm_command} --set bearer_token=${bearer_token}"
 fi
 
+if [[ $application_name == 'fb-service-token-cache' ]]; then
+  # The clusters (K8S and EKS) have different names for their bearer tokens
+  # So these tokens have been set in the deployment pipeline
+  # Each token is different also per environment (test-dev, test-production,
+  # live-dev and live-production) so it needs this dynamic grep for
+  # K8S_BEARER_TOKEN_TEST_DEV, K8S_BEARER_TOKEN_LIVE_DEV etc
+  bearer_token_env_var_name="K8S_BEARER_TOKEN_${platform_environment}_${deployment_environment}"
+  bearer_token_env_var_name=$(echo $bearer_token_env_var_name | tr [a-z] [A-Z])
+  bearer_token=$(eval "echo \${$bearer_token_env_var_name}")
+  helm_command="${helm_command} --set bearer_token=${bearer_token}"
+fi
+
 echo "*******************************************************************"
 echo "Full helm command"
 echo $helm_command

--- a/bin/deploy-eks
+++ b/bin/deploy-eks
@@ -169,6 +169,18 @@ if [[ $application_name == 'fb-publisher' ]]; then
   helm_command="${helm_command} --set bearer_token=${bearer_token}"
 fi
 
+if [[ $application_name == 'fb-service-token-cache' ]]; then
+  # The clusters (K8S and EKS) have different names for their bearer tokens
+  # So these tokens have been set in the deployment pipeline
+  # Each token is different also per environment (test-dev, test-production,
+  # live-dev and live-production) so it needs this dynamic grep for
+  # EKS_BEARER_TOKEN_TEST_DEV, EKS_BEARER_TOKEN_LIVE_DEV etc
+  bearer_token_env_var_name="EKS_BEARER_TOKEN_${platform_environment}_${deployment_environment}"
+  bearer_token_env_var_name=$(echo $bearer_token_env_var_name | tr [a-z] [A-Z])
+  bearer_token=$(eval "echo \${$bearer_token_env_var_name}")
+  helm_command="${helm_command} --set bearer_token=${bearer_token}"
+fi
+
 echo "*******************************************************************"
 echo "Full helm command"
 echo $helm_command


### PR DESCRIPTION
[Trello](https://trello.com/c/Ad7E2yU1/2070-eks-021-migrate-service-token-cache-to-test-dev-and-test-production)

Since the bearer tokens are hard coded, we need to adapt the tokens depending on which platform and deployment environment (eg: test-dev) and on whether we are deploying to the K8S or EKS cluster.