### PR TITLE
Add bearer token to the editor

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -157,7 +157,7 @@ fi
 echo "*******************************************************************"
 echo
 
-if [[ $application_name == 'fb-publisher' ]]; then
+if [[ $application_name == 'fb-publisher' || $application_name == 'fb-editor' ]]; then
   # The clusters (K8S and EKS) have different names for their bearer tokens
   # So these tokens have been set in the deployment pipeline
   # Each token is different also per environment (test and live) so

--- a/bin/deploy-eks
+++ b/bin/deploy-eks
@@ -157,7 +157,7 @@ fi
 echo "*******************************************************************"
 echo
 
-if [[ $application_name == 'fb-publisher' ]]; then
+if [[ $application_name == 'fb-publisher' || $application_name == 'fb-editor' ]]; then
   # The clusters (K8S and EKS) have different names for their bearer tokens
   # So these tokens have been set in the deployment pipeline
   # Each token is different also per environment (test and live) so


### PR DESCRIPTION

As similar to the publisher app we need the token in the ENV var.

The ENV vars were added to Circle already:

* K8S_BEARER_TOKEN_TEST
* K8S_BEARER_TOKEN_LIVE
* EKS_BEARER_TOKEN_TEST

The saas-live still doesn't exist hence I didn't add the `EKS_BEARER_TOKEN_LIVE` yet.