### PR TITLE
Remove disable_branching flag from deploy script

### DIFF
--- a/bin/deploy-eks
+++ b/bin/deploy-eks
@@ -148,33 +148,13 @@ else
   # they can potentially use the same mechanism the editor does
   echo "Setting app_name to ${application_name}"
 
-  disable_branching=${DISABLE_BRANCHING-}
-  if [ -z "$disable_branching" ]; then
-    echo "Standard deployment branch"
+  helm_command="helm template deploy-eks/${chartname} $helm_command --set circleSha1=${build_SHA} \
+  --set environmentName=${environment_full_name} --set platformEnv=${platform_environment} \
+  --set app_name=${application_name}"
 
-    if [[ $platform_environment == 'test' ]] && [[ $application_name == 'fb-editor' ]]; then
-      editor_host="${application_name}-${platform_environment}.apps.live.cloud-platform.service.justice.gov.uk"
-      helm_command="helm template deploy-eks/${chartname} $helm_command --set circleSha1=${build_SHA} \
-      --set environmentName=${environment_full_name} --set platformEnv=${platform_environment} \
-      --set app_name=${application_name} --set editor_host=${editor_host}"
-    else
-      # disable_branching environment variable is not there so it is a standard deploy
-      helm_command="helm template deploy-eks/${chartname} $helm_command --set circleSha1=${build_SHA} \
-      --set environmentName=${environment_full_name} --set platformEnv=${platform_environment} \
-      --set app_name=${application_name}"
-    fi
-  else
-    # disable_branching is only used by the editor app
-    app_name=fb-editor-test-no-branching
-    editor_host="${app_name}.apps.live.cloud-platform.service.justice.gov.uk"
-    echo "Deploying the no branching test editor. Setting editor_host to ${editor_host}"
-
-    # set the app_name to be the name of the no branching editor
-    echo "Setting app_name to ${app_name}"
-
-    helm_command="helm template deploy-eks/${chartname} $helm_command --set circleSha1=${build_SHA} \
-    --set environmentName=${environment_full_name} --set platformEnv=${platform_environment} \
-    --set editor_host=${editor_host} --set app_name=${app_name} --set disable_branching=true"
+  if [[ $platform_environment == 'test' ]] && [[ $application_name == 'fb-editor' ]]; then
+    editor_host="${application_name}-${platform_environment}.apps.live.cloud-platform.service.justice.gov.uk"
+    helm_command="${helm_command} --set editor_host=${editor_host}"
   fi
 fi
 echo "*******************************************************************"


### PR DESCRIPTION
[Trello](https://trello.com/c/KSPPNDkC/2407-branching-flag-clean-up-in-the-code-base)

While developing the branching feature, the `disable_branching=true` flag was present only in the live environment.
Now that branching has been released we no longer need this flag.