### PR TITLE
Update deploy script to cater for fb-av deployment to saas-test

### DIFF
--- a/bin/deploy-eks
+++ b/bin/deploy-eks
@@ -188,6 +188,18 @@ if [[ $application_name == 'fb-service-token-cache' ]]; then
   helm_command="${helm_command} --set bearer_token=${bearer_token}"
 fi
 
+  # The fb-av app is deployed in two namespaces, the platform and saas.
+  # So different apps need to access the fb-av app depending on which
+  # namespace fb-av is deployed into. The user filestore requires access
+  # in the platform namespace. The editor requires access in the saas namespace.
+if [[ $application_name == 'fb-av' ]]; then
+  if [ -z "$deployment_environment" ]; then
+    helm_command="${helm_command} --set accessing_app=fb-editor-web-${environment_full_name}"
+  else
+    helm_command="${helm_command} --set accessing_app=fb-user-filestore-api-${environment_full_name}"
+  fi
+fi
+
 echo "*******************************************************************"
 echo "Full helm command"
 echo $helm_command

--- a/bin/deploy-eks
+++ b/bin/deploy-eks
@@ -150,7 +150,11 @@ else
 
   helm_command="helm template deploy-eks/${chartname} $helm_command --set circleSha1=${build_SHA} \
   --set environmentName=${environment_full_name} --set platformEnv=${platform_environment} \
-  --set app_name=${application_name}"
+  --set app_name=${application_name} --set namespace=${namespace}"
+
+  echo "*******************************************************************"
+  echo "Helm command is ${helm_command}"
+  echo "*******************************************************************"
 
   if [[ $platform_environment == 'test' ]] && [[ $application_name == 'fb-editor' ]]; then
     editor_host="${application_name}-${platform_environment}.apps.live.cloud-platform.service.justice.gov.uk"


### PR DESCRIPTION
[Trello](https://trello.com/c/MPnUo7jW/2752-autocomplete-editor-fb-av)
Relates to [PR](https://github.com/ministryofjustice/fb-av/pull/50)

### Set namespace variable in helm
We require the namespace value in the deployment of the fb-av app. This is because the fb-av app is deployed into two namespaces, the platform and the saas namespaces.

### Ensure the correct apps can access fb-av
The fb-av app is deployed in two namespaces, the platform and saas. As such, different apps need to access the fb-av app depending on which namespace fb-av is deployed into. For the platform namespace, the user filestore requires access and in the saas namespace, the editor requires access.

Co-authored-by: Brendan Butler <brendan.butler@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>