### PR TITLE
Add Rotate EKS tokens scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/scripts/eks_bearer_token.rb
+++ b/scripts/eks_bearer_token.rb
@@ -1,0 +1,39 @@
+namespace = ARGV[0]
+app_name = ARGV[1]
+
+exit 1 if namespace.nil?
+exit 1 if app_name.nil?
+
+secrets = `kubectl get secrets -n #{namespace}`
+
+secrets.split(' ').each do |element|
+  if element.include?(app_name) && element.start_with?('formbuilder')
+    puts element
+
+    user_input = STDIN.gets.chomp
+
+    if user_input == 'y'
+      `kubectl delete secret -n formbuilder-platform-test-dev #{element}`
+
+      sleep(5)
+
+      secrets = `kubectl get secrets -n #{namespace}`
+
+      secrets.split(' ').each do |element|
+        if element.include?(app_name) && element.start_with?('formbuilder')
+          puts "***************************"
+          puts "your new secret is"
+          puts 'variable name ->'
+          puts 'EKS_BEARER_TOKEN_' + namespace.split('-')[2..].map(&:upcase).join('_')
+          puts 'variable value  ->'
+          puts element
+          puts "***************************"
+        end
+      end
+    else
+      puts 'goodbye'
+      exit 0
+    end
+  end
+end
+

--- a/scripts/eks_token.rb
+++ b/scripts/eks_token.rb
@@ -1,0 +1,35 @@
+namespace = ARGV[0]
+
+exit 1 if namespace.nil?
+
+secrets = `kubectl get secrets -n #{namespace}`
+secrets.split(' ').each do |element|
+  if element.start_with?('circleci-formbuilder')
+    puts element
+
+    user_input = STDIN.gets.chomp
+
+    if user_input == 'y'
+      `kubectl delete secret -n formbuilder-platform-test-dev #{element}`
+
+      sleep(5)
+
+      secrets = `kubectl get secrets -n #{namespace}`
+      secrets.split(' ').each do |element|
+        if element.start_with?('circleci-formbuilder')
+          puts "***************************"
+          puts "your new secret is"
+          puts 'variable name ->'
+          puts 'EKS_TOKEN_' + namespace.split('-')[2..].map(&:upcase).join('_')
+          puts 'variable value  ->'
+          puts `kubectl get secrets -n #{namespace} #{element} -o jsonpath="{.data.token}"`
+          puts "***************************"
+        end
+      end
+    else
+      puts 'goodbye'
+      exit 0
+    end
+  end
+end
+


### PR DESCRIPTION
This adds to ruby scripts:

- eks_token.rb
- eks_bearer_token.rb

Both scripts will delete the old secrets when they are run. They require
prompting by the dev running the script.

eks_token.rb will get the EKS token itself out of the CircleCI secret
for a given namespace and print to screen along with the correct
variable name that needs to be set in the CircleCI pipeline
configuration.

`ruby eks_token.rb <namespace>`

eks_bearer_token.rb gets the specific app secret prefixed with
'formbuilder-<app_name>' and prints out the name of that secret and the
name of the environment variable that should be used in the CircleCI
pipeline configuration.

`ruby eks_bearer_token.rb <namespace> <app_name>`

Co-authored-by: Chris Pymm <chris.pymm@digital.justice.gov.uk>
Co-authored-by: Matt Tei <matt.tei@digital.justice.gov.uk>
Co-authored-by: Hellema Ibrahim <hellema.ibrahim@digital.justice.gov.uk>
Co-authored-by: Steven Leighton <steven.leighton@digital.justice.gov.uk>