### PR TITLE
Specify apps that use a root level Dockerfile

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -136,6 +136,8 @@ ecr_credentials=$(kubectl get secrets -n formbuilder-repos)
 echo "*******************************************************************"
 echo
 
+top_level_docker_files=("ecr-repo-fb-user-datastore-api" "ecr-repo-fb-user-filestore-api")
+
 for ecr_credential in ${ecr_credentials[@]}; do
   if [[ ${ecr_credential} == *"${ecr_credentials_secret}"* ]]; then
     # Despite this saying it is a secret and/or credential, this is in fact just
@@ -158,7 +160,14 @@ for ecr_credential in ${ecr_credentials[@]}; do
     # ecr-repo-fb-submitter-api) the dockerfile to be build will be
     # located in docker/worker/Dockerfile
     #
-    if [[ $application_type == $ecr_credentials_secret ]]; then
+    top_level=false
+    for str in "${top_level_docker_files[@]}"; do
+      if [[ $ecr_credentials_secret == "$str" ]]; then
+        top_level=true
+      fi
+    done
+
+    if [[ $application_type == "$ecr_credentials_secret" ]] || [[ $top_level ]]; then
       dockerfile="./Dockerfile"
     else
       dockerfile="./docker/${application_type}/Dockerfile"

--- a/bin/build
+++ b/bin/build
@@ -193,6 +193,12 @@ for ecr_credential in ${ecr_credentials[@]}; do
         export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
         export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
         export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)
+
+        if [[ -z $AWS_ACCESS_KEY_ID ]] || [[ -z $AWS_SECRET_ACCESS_KEY ]] || [[ -z $ECR_REPO_URL ]]; then
+          echo "AWS Credentials were not set correctly"
+          exit 1
+        fi
+
         echo "*******************************************************************"
         echo
 


### PR DESCRIPTION
Some of the apps have top level docker files and others have API or
Worker directories containing docker files.

 
## Exit if AWS creds are not found

If we cannot retrieve the AWS credentials and the script is unable to
log in we want the pipeline to stop there and not continue

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>
Co-authored-by: Matt Tei <[matt.tei@digital.justice.gov.uk](mailto:matt.tei@digital.justice.gov.uk)>
Co-authored-by: Hellema Ibrahim <[hellema.ibrahim@digital.justice.gov.uk](mailto:hellema.ibrahim@digital.justice.gov.uk)>
Co-authored-by: Steven Leighton <steven.leighton@digital.justice.gov.uk>