### PR TITLE
Add script to return service names, platform and url

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,12 @@ In addition to the above, you will also need to set the following configuration 
 You can run the following command to find the correct `EKS_NAMESPACE` that you require for the app you are deploying:
 
 `kubectl get namespaces | grep formbuilder`
+
+## Getting the existing service names and urls in a namespace
+
+To check what services are currently running in Kubernetes pods we can run the `get_service_names_and_urls` script.
+
+To run:
+`./bin/get_service_names_and_urls <namespace>`
+
+This script will print out the service name, the platform it is running on (Legacy or MoJ Forms) and the URL for the service.

--- a/bin/get_service_names_and_urls
+++ b/bin/get_service_names_and_urls
@@ -1,0 +1,65 @@
+#!/usr/bin/env sh
+set -e -u -o pipefail
+
+namespace=$1
+fb_runner_image_url=$(kubectl get secrets -n formbuilder-repos ecr-repo-fb-runner -o json | jq -r '.data["repo_url"]' | base64 -D)
+fb_runner_node_image_url=$(kubectl get secrets -n formbuilder-repos ecr-repo-fb-runner-node -o json | jq -r '.data["repo_url"]' | base64 -D)
+maintenance_page_image_url=$(kubectl get secrets -n formbuilder-repos ecr-repo-fb-maintenance-page -o json | jq -r '.data["repo_url"]' | base64 -D)
+test_dev='test-dev'
+test_production='test-production'
+live_dev='live-dev'
+live_production='live-production'
+
+if [ $namespace != $test_dev ] && [ $namespace != $test_production ] && [ $namespace != $live_dev ] && [ $namespace != $live_production ] ; then
+  echo 'Please enter namespace test-dev or test-production'
+  exit 1;
+fi
+service_names="$(kubectl get deployments -n formbuilder-services-${namespace}  --output=jsonpath={.items..metadata.name})"
+
+get_service_name_and_url () {
+  for service in ${service_names}; do
+    list_image=$(kubectl get deployments -n formbuilder-services-$1 ${service} -o=jsonpath='{$.spec.template.spec.containers[:1].image}')
+
+    if [[ "$list_image" == *"${fb_runner_node_image_url}:latest-$3"* ]]; then
+      echo "============================================================="
+      echo "Service: ${service}"
+      echo "Platform: LEGACY"
+      echo "URL: https://${service}.$2"
+      echo "============================================================="
+    fi
+
+    if [[ "$list_image" == *"${maintenance_page_image_url}:latest"* ]]; then
+      echo "========================================="
+      echo "Service: ${service} is maintenance page"
+      echo "========================================="
+    fi
+
+    if [[ "$list_image" == *"${fb_runner_image_url}:latest-$3"* ]]; then
+      echo "============================================================="
+      echo "Service: ${service}"
+      echo "Platform: MoJ Forms"
+      echo "URL: https://${service}.$2"
+      echo "============================================================="
+    fi
+  done
+}
+
+echo "=========================================================="
+echo "| Getting services for formbuilder-services-${namespace} |"
+echo "=========================================================="
+
+if [[ "$namespace" == "$test_dev" ]]; then
+  get_service_name_and_url ${namespace} "dev.test.form.service.justice.gov.uk/" "test"
+fi
+
+if [[ "$namespace" == *"$test_production"* ]]; then
+  get_service_name_and_url ${namespace} "test.form.service.justice.gov.uk/" "test"
+fi
+
+if [[ "$namespace" == *"$live_dev"* ]]; then
+  get_service_name_and_url ${namespace} "dev.form.service.justice.gov.uk/" "live"
+fi
+
+if [[ "$namespace" == *"$live_production"* ]]; then
+  get_service_name_and_url ${namespace} "form.service.justice.gov.uk/" "live"
+fi


### PR DESCRIPTION
Add a script to audit the service names and urls that are currently existing on our kubernetes network.

Example of usage and output:
```
> ./get_service_names_and_urls test-production
==========================================================
| Getting services for formbuilder-services-test-production |
==========================================================
=========================================================
Service: contact-us-about-a-case
Platform: MoJ Forms
URL: https://contact-us-about-a-case.test.form.service.justice.gov.uk/
=========================================================
=======================================
Service: fb-maintenance-page is a maintenance page
=======================================
=========================================================
Service: song-builder
Platform: LEGACY
URL: https://song-builder.test.form.service.justice.gov.uk/
=========================================================
```