### PR TITLE
Use short-lived ECR access tokens

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -123,13 +123,6 @@ echo
 
 set_context "circleci" "${k8s_namespace}" "${k8s_token}" "${cluster_cert}" "${cluster_name}"
 
-# echo "*******************************************************************"
-# echo "Getting ECR credentials"
-# ecr_username=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_username}" | base64 -d)
-# ecr_password=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_password}" | base64 -d)
-# echo "*******************************************************************"
-# echo
-
 echo "*******************************************************************"
 echo "Finding right ecr repos from ${k8s_namespace}"
 ecr_credentials=$(kubectl get secrets -n formbuilder-repos)

--- a/bin/build
+++ b/bin/build
@@ -207,7 +207,9 @@ for ecr_credential in ${ecr_credentials[@]}; do
 
         echo "*******************************************************************"
         echo 'Logging into AWS ECR'
-        aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
+        # aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
+        aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com
+
         export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
 
         build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}

--- a/bin/build
+++ b/bin/build
@@ -200,6 +200,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
 
         aws sts assume-role \
         --role-arn "${ECR_ROLE_TO_ASSUME}" \
+        --role-session-name "fb-deploy-ecr-session" \
         --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
         --output text
         

--- a/bin/build
+++ b/bin/build
@@ -189,22 +189,8 @@ for ecr_credential in ${ecr_credentials[@]}; do
         echo "Using Dockerfile from ${dockerfile}"
         echo "*******************************************************************"
         echo
-
-        # echo "*******************************************************************"
-        # echo "Getting secrets from AWS"
         export AWS_DEFAULT_REGION=$ECR_REGION
-        # export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
-        # export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
-        # export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)
-
-        # if [[ -z $AWS_ACCESS_KEY_ID ]] || [[ -z $AWS_SECRET_ACCESS_KEY ]] || [[ -z $ECR_REPO_URL ]]; then
-        #   echo "AWS Credentials were not set correctly"
-        #   exit 1
-        # fi
-
-        # echo "*******************************************************************"
-        # echo
-
+        # We used to use long lived creds for this login, we now login in the circle jobs using an orb and output the ~/.aws/config data to $BASH_ENV
         echo "*******************************************************************"
         echo 'Logging into AWS ECR'
         aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com

--- a/bin/build
+++ b/bin/build
@@ -212,6 +212,10 @@ for ecr_credential in ${ecr_credentials[@]}; do
 
         export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
 
+        if [[ ${ecr_credential} == 'ecr-repo-fb-submitter-workers']]; then
+          export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
+        fi
+
         build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
       fi
     else

--- a/bin/build
+++ b/bin/build
@@ -60,7 +60,7 @@ build_and_push() {
     # The other apps make use of the build SHA as the tag
     echo "*******************************************************************"
     echo "Runner app. Building ${repo_name}:latest-$2"
-    docker build -t "$1:latest-$2" -f "$4" .
+    docker build --no-cache -t "$1:latest-$2" -f "$4" .
     echo "*******************************************************************"
     echo
 
@@ -213,6 +213,9 @@ for ecr_credential in ${ecr_credentials[@]}; do
         export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
 
         if [[ $ecr_credential == 'ecr-repo-fb-submitter-workers' ]] && [[ $BUILD_WORKER == 'true' ]]; then
+          echo "*******************************************************************"
+          echo "Building submitter worker"
+          echo "*******************************************************************"
           export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         else

--- a/bin/build
+++ b/bin/build
@@ -212,11 +212,12 @@ for ecr_credential in ${ecr_credentials[@]}; do
 
         export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
 
-        if [[ $ecr_credential == 'ecr-repo-fb-submitter-workers' ]]; then
+        if [[ $ecr_credential == 'ecr-repo-fb-submitter-workers' ]] && [[ $BUILD_WORKER == 'true' ]]; then
           export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
+          build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
+        else
+          build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
-
-        build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
       fi
     else
       echo "*******************************************************************"

--- a/bin/build
+++ b/bin/build
@@ -199,7 +199,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
         echo "Assume role and identity"
 
         aws sts assume-role-with-web-identity \
-        --role-arn "${$ECR_ROLE_TO_ASSUME}" \
+        --role-arn "${ECR_ROLE_TO_ASSUME}" \
         --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
         --output text
         

--- a/bin/build
+++ b/bin/build
@@ -219,6 +219,9 @@ for ecr_credential in ${ecr_credentials[@]}; do
           export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         else
+          # do nothing
+        fi
+        if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]]; then
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
       fi

--- a/bin/build
+++ b/bin/build
@@ -212,7 +212,15 @@ for ecr_credential in ${ecr_credentials[@]}; do
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
 
-        if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]] && [[ $ecr_credential != 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]] && [[ $BUILD_WORKER != 'true' ]]; then
+        if [[ $ecr_credential == 'ecr-repo-fb-publisher-worker' ]] && [[ $BUILD_WORKER == 'true' ]]; then
+          echo "*******************************************************************"
+          echo "Building publisher worker"
+          echo "*******************************************************************"
+          export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
+          build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
+        fi
+
+        if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]] && [[ $ecr_credential != 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]] && [[ $ecr_credential != 'ecr-repo-fb-publisher-worker' ]] && [[ $BUILD_WORKER != 'true' ]]; then
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
       fi

--- a/bin/build
+++ b/bin/build
@@ -127,8 +127,6 @@ echo "*******************************************************************"
 echo "Getting ECR credentials"
 ecr_username=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_username}" | base64 -d)
 ecr_password=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_password}" | base64 -d)
-
-
 echo "*******************************************************************"
 echo
 
@@ -192,55 +190,28 @@ for ecr_credential in ${ecr_credentials[@]}; do
         echo "*******************************************************************"
         echo
 
-        echo "*******************************************************************"
-        echo "Getting secrets from AWS"
+        # echo "*******************************************************************"
+        # echo "Getting secrets from AWS"
+        # export AWS_DEFAULT_REGION=eu-west-2
+        # export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
+        # export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
+        # export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)
 
-        echo "*******************************************************************"
-        echo "Assume role and identity"
+        # if [[ -z $AWS_ACCESS_KEY_ID ]] || [[ -z $AWS_SECRET_ACCESS_KEY ]] || [[ -z $ECR_REPO_URL ]]; then
+        #   echo "AWS Credentials were not set correctly"
+        #   exit 1
+        # fi
 
-        aws sts assume-role \
-        --role-arn "${ECR_ROLE_TO_ASSUME}" \
-        --role-session-name "fb-deploy-ecr-session" \
-        --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-        --output text
-        
+        # echo "*******************************************************************"
+        # echo
 
-        if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then
-            echo "Failed to assume role";
-            exit 1
-        else 
-            {
-                echo "export AWS_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\""
-                echo "export AWS_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\""
-                echo "export AWS_SESSION_TOKEN=\"${AWS_SESSION_TOKEN}\""
-            } >>"$BASH_ENV"
-            echo "Assume role with web identity succeeded"
-        fi
-        echo "*******************************************************************"
+        # echo "*******************************************************************"
+        # echo 'Logging into AWS ECR'
+        # aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
+        # echo "*******************************************************************"
+        # echo
 
-
-
-        export AWS_DEFAULT_REGION=eu-west-2
-        export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
-        export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
-        export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)
-
-
-        if [[ -z $AWS_ACCESS_KEY_ID ]] || [[ -z $AWS_SECRET_ACCESS_KEY ]] || [[ -z $ECR_REPO_URL ]]; then
-          echo "AWS Credentials were not set correctly"
-          exit 1
-        fi
-
-        echo "*******************************************************************"
-        echo
-
-        echo "*******************************************************************"
-        echo 'Logging into AWS ECR'
-        aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
-        echo "*******************************************************************"
-        echo
-
-        build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
+        build_and_push ${ECR_REPOSITORY} ${environment_name} ${build_SHA}  ${dockerfile}
       fi
     else
       echo "*******************************************************************"

--- a/bin/build
+++ b/bin/build
@@ -233,7 +233,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
 
-        if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]] && [[ $ecr_credential != 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]]; then
+        if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]] && [[ $ecr_credential != 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]] && [[ $BUILD_WORKER != 'true' ]]; then
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
       fi

--- a/bin/build
+++ b/bin/build
@@ -198,7 +198,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
         echo "*******************************************************************"
         echo "Assume role and identity"
 
-        aws sts assume-role-with-web-identity \
+        aws sts assume-role \
         --role-arn "${ECR_ROLE_TO_ASSUME}" \
         --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
         --output text

--- a/bin/build
+++ b/bin/build
@@ -127,6 +127,8 @@ echo "*******************************************************************"
 echo "Getting ECR credentials"
 ecr_username=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_username}" | base64 -d)
 ecr_password=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_password}" | base64 -d)
+
+
 echo "*******************************************************************"
 echo
 
@@ -192,10 +194,36 @@ for ecr_credential in ${ecr_credentials[@]}; do
 
         echo "*******************************************************************"
         echo "Getting secrets from AWS"
+
+        echo "*******************************************************************"
+        echo "Assume role and identity"
+
+        read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN <<EOF
+ 
+        $(aws sts assume-role-with-web-identity --role-arn $ECR_ROLE_TO_ASSUME \
+          --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+          --output text)
+        EOF
+        if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then
+            echo "Failed to assume role";
+            exit 1
+        else 
+            {
+                echo "export AWS_ACCESS_KEY_ID=\"${AWS_ACCESS_KEY_ID}\""
+                echo "export AWS_SECRET_ACCESS_KEY=\"${AWS_SECRET_ACCESS_KEY}\""
+                echo "export AWS_SESSION_TOKEN=\"${AWS_SESSION_TOKEN}\""
+            } >>"$BASH_ENV"
+            echo "Assume role with web identity succeeded"
+        fi
+        echo "*******************************************************************"
+
+
+
         export AWS_DEFAULT_REGION=eu-west-2
         export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
         export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
         export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)
+
 
         if [[ -z $AWS_ACCESS_KEY_ID ]] || [[ -z $AWS_SECRET_ACCESS_KEY ]] || [[ -z $ECR_REPO_URL ]]; then
           echo "AWS Credentials were not set correctly"

--- a/bin/build
+++ b/bin/build
@@ -198,12 +198,12 @@ for ecr_credential in ${ecr_credentials[@]}; do
         echo "*******************************************************************"
         echo "Assume role and identity"
 
-        read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN <<EOF
+        read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN 
         $(aws sts assume-role-with-web-identity \
         --role-arn "${$ECR_ROLE_TO_ASSUME}" \
         --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
         --output text)
-        EOF
+        
 
         if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then
             echo "Failed to assume role";

--- a/bin/build
+++ b/bin/build
@@ -198,10 +198,10 @@ for ecr_credential in ${ecr_credentials[@]}; do
         echo "*******************************************************************"
         echo "Assume role and identity"
 
-        echo $(aws sts assume-role-with-web-identity \
+        aws sts assume-role-with-web-identity \
         --role-arn "${$ECR_ROLE_TO_ASSUME}" \
         --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-        --output text)
+        --output text
         
 
         if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then

--- a/bin/build
+++ b/bin/build
@@ -208,14 +208,9 @@ for ecr_credential in ${ecr_credentials[@]}; do
         # echo "*******************************************************************"
         # echo 'Logging into AWS ECR'
         # aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
-        export COOL_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
-        echo "*******************************************************************"
-        echo $ECR_REPOSITORY
-        echo $COOL_URL
-        echo "*******************************************************************"
+        export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
 
-
-        build_and_push $ECR_REPOSITORY ${environment_name} ${build_SHA}  ${dockerfile}
+        build_and_push $ECR_REPO_URL ${environment_name} ${build_SHA}  ${dockerfile}
       fi
     else
       echo "*******************************************************************"

--- a/bin/build
+++ b/bin/build
@@ -212,7 +212,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
 
         export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
 
-        if [[ ${ecr_credential} == 'ecr-repo-fb-submitter-workers']]; then
+        if [[ $ecr_credential == 'ecr-repo-fb-submitter-workers' ]]; then
           export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
         fi
 

--- a/bin/build
+++ b/bin/build
@@ -208,10 +208,12 @@ for ecr_credential in ${ecr_credentials[@]}; do
         # echo "*******************************************************************"
         # echo 'Logging into AWS ECR'
         # aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
-        # echo "*******************************************************************"
-        # echo
+        echo "*******************************************************************"
+        echo $ECR_REPOSITORY
+        echo "*******************************************************************"
 
-        build_and_push ${ECR_REPOSITORY} ${environment_name} ${build_SHA}  ${dockerfile}
+
+        build_and_push $ECR_REPOSITORY ${environment_name} ${build_SHA}  ${dockerfile}
       fi
     else
       echo "*******************************************************************"

--- a/bin/build
+++ b/bin/build
@@ -208,8 +208,10 @@ for ecr_credential in ${ecr_credentials[@]}; do
         # echo "*******************************************************************"
         # echo 'Logging into AWS ECR'
         # aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
+        export COOL_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
         echo "*******************************************************************"
         echo $ECR_REPOSITORY
+        echo $COOL_URL
         echo "*******************************************************************"
 
 

--- a/bin/build
+++ b/bin/build
@@ -207,11 +207,16 @@ for ecr_credential in ${ecr_credentials[@]}; do
 
         echo "*******************************************************************"
         echo 'Logging into AWS ECR'
-        # aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
         aws ecr get-login-password --region $ECR_REGION | docker login --username AWS --password-stdin ${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com
 
         export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
 
+
+        # I've had to introduce special cases for each repo that needs to build workers on migrating to OIDC ECR creds in September '23
+        # Previously these scripts had an elegant way of determining between workers and API images, but now need to use separate AWS login role arns to access ECR for them
+        # This login is done in a separate step in the circle pipeline so had to split build steps into build-api and build-worker
+        # We still have the list of secrets in formbuilder-repos for this script to work, but they no longer contain long-lived access keys, they're essentially just a list of our
+        # available repositories
         if [[ $ecr_credential == 'ecr-repo-fb-submitter-workers' ]] && [[ $BUILD_WORKER == 'true' ]]; then
           echo "*******************************************************************"
           echo "Building submitter worker"
@@ -219,7 +224,16 @@ for ecr_credential in ${ecr_credentials[@]}; do
           export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
-        if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]]; then
+
+        if [[ $ecr_credential == 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]] && [[ $BUILD_WORKER == 'true' ]]; then
+          echo "*******************************************************************"
+          echo "Building adapter worker"
+          echo "*******************************************************************"
+          export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
+          build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
+        fi
+
+        if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]] && [[ $ecr_credential != 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]]; then
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
       fi

--- a/bin/build
+++ b/bin/build
@@ -60,7 +60,7 @@ build_and_push() {
     # The other apps make use of the build SHA as the tag
     echo "*******************************************************************"
     echo "Runner app. Building ${repo_name}:latest-$2"
-    docker build --no-cache -t "$1:latest-$2" -f "$4" .
+    docker build -t "$1:latest-$2" -f "$4" .
     echo "*******************************************************************"
     echo
 

--- a/bin/build
+++ b/bin/build
@@ -210,7 +210,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
         aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
         export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
 
-        build_and_push $ECR_REPO_URL ${environment_name} ${build_SHA}  ${dockerfile}
+        build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
       fi
     else
       echo "*******************************************************************"

--- a/bin/build
+++ b/bin/build
@@ -205,9 +205,9 @@ for ecr_credential in ${ecr_credentials[@]}; do
         # echo "*******************************************************************"
         # echo
 
-        # echo "*******************************************************************"
-        # echo 'Logging into AWS ECR'
-        # aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
+        echo "*******************************************************************"
+        echo 'Logging into AWS ECR'
+        aws ecr get-login-password --region eu-west-2 | docker login --username ${ecr_username} --password-stdin ${ecr_password}
         export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${ECR_REPOSITORY}
 
         build_and_push $ECR_REPO_URL ${environment_name} ${build_SHA}  ${dockerfile}

--- a/bin/build
+++ b/bin/build
@@ -123,12 +123,12 @@ echo
 
 set_context "circleci" "${k8s_namespace}" "${k8s_token}" "${cluster_cert}" "${cluster_name}"
 
-echo "*******************************************************************"
-echo "Getting ECR credentials"
-ecr_username=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_username}" | base64 -d)
-ecr_password=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_password}" | base64 -d)
-echo "*******************************************************************"
-echo
+# echo "*******************************************************************"
+# echo "Getting ECR credentials"
+# ecr_username=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_username}" | base64 -d)
+# ecr_password=$(kubectl get secrets -n formbuilder-repos ecr-credentials -o jsonpath="{.data.ecr_password}" | base64 -d)
+# echo "*******************************************************************"
+# echo
 
 echo "*******************************************************************"
 echo "Finding right ecr repos from ${k8s_namespace}"

--- a/bin/build
+++ b/bin/build
@@ -218,8 +218,6 @@ for ecr_credential in ${ecr_credentials[@]}; do
           echo "*******************************************************************"
           export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
-        else
-          # do nothing
         fi
         if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]]; then
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}

--- a/bin/build
+++ b/bin/build
@@ -198,8 +198,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
         echo "*******************************************************************"
         echo "Assume role and identity"
 
-        read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN 
-        $(aws sts assume-role-with-web-identity \
+        echo $(aws sts assume-role-with-web-identity \
         --role-arn "${$ECR_ROLE_TO_ASSUME}" \
         --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
         --output text)

--- a/bin/build
+++ b/bin/build
@@ -199,11 +199,12 @@ for ecr_credential in ${ecr_credentials[@]}; do
         echo "Assume role and identity"
 
         read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN <<EOF
- 
-        $(aws sts assume-role-with-web-identity --role-arn $ECR_ROLE_TO_ASSUME \
-          --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
-          --output text)
+        $(aws sts assume-role-with-web-identity \
+        --role-arn "${$ECR_ROLE_TO_ASSUME}" \
+        --query 'Credentials.[AccessKeyId,SecretAccessKey,SessionToken]' \
+        --output text)
         EOF
+
         if [ -z "${AWS_ACCESS_KEY_ID}" ] || [ -z "${AWS_SECRET_ACCESS_KEY}" ] || [ -z "${AWS_SESSION_TOKEN}" ]; then
             echo "Failed to assume role";
             exit 1

--- a/bin/build
+++ b/bin/build
@@ -196,14 +196,6 @@ for ecr_credential in ${ecr_credentials[@]}; do
         # This login is done in a separate step in the circle pipeline so had to split build steps into build-api and build-worker
         # We still have the list of secrets in formbuilder-repos for this script to work, but they no longer contain long-lived access keys, they're essentially just a list of our
         # available repositories
-        if [[ $ecr_credential == 'ecr-repo-fb-editor-workers' ]] && [[ $BUILD_WORKER == 'true' ]]; then
-          echo "*******************************************************************"
-          echo "Building editor worker"
-          echo "*******************************************************************"
-          export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
-          build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
-        fi
-
         if [[ $ecr_credential == 'ecr-repo-fb-submitter-workers' ]] && [[ $BUILD_WORKER == 'true' ]]; then
           echo "*******************************************************************"
           echo "Building submitter worker"
@@ -228,7 +220,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
 
-        if [[ $ecr_credential != 'ecr-repo-fb-editor-workers' ]] && [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]] && [[ $ecr_credential != 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]] && [[ $ecr_credential != 'ecr-repo-fb-publisher-worker' ]] && [[ $BUILD_WORKER != 'true' ]]; then
+        if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]] && [[ $ecr_credential != 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]] && [[ $ecr_credential != 'ecr-repo-fb-publisher-worker' ]] && [[ $BUILD_WORKER != 'true' ]]; then
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
       fi

--- a/bin/build
+++ b/bin/build
@@ -192,7 +192,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
 
         # echo "*******************************************************************"
         # echo "Getting secrets from AWS"
-        # export AWS_DEFAULT_REGION=eu-west-2
+        export AWS_DEFAULT_REGION=$ECR_REGION
         # export AWS_ACCESS_KEY_ID=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.access_key_id}' | base64 -d)
         # export AWS_SECRET_ACCESS_KEY=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.secret_access_key}' | base64 -d)
         # export ECR_REPO_URL=$(kubectl get secrets -n formbuilder-repos ${ecr_credential} -o jsonpath='{.data.repo_url}' | base64 -d)

--- a/bin/build
+++ b/bin/build
@@ -196,6 +196,14 @@ for ecr_credential in ${ecr_credentials[@]}; do
         # This login is done in a separate step in the circle pipeline so had to split build steps into build-api and build-worker
         # We still have the list of secrets in formbuilder-repos for this script to work, but they no longer contain long-lived access keys, they're essentially just a list of our
         # available repositories
+        if [[ $ecr_credential == 'ecr-repo-fb-editor-workers' ]] && [[ $BUILD_WORKER == 'true' ]]; then
+          echo "*******************************************************************"
+          echo "Building editor worker"
+          echo "*******************************************************************"
+          export ECR_REPO_URL=${AWS_ECR_REGISTRY_ID}.dkr.ecr.${ECR_REGION}.amazonaws.com/${WORKERS_ECR_REPOSITORY}
+          build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
+        fi
+
         if [[ $ecr_credential == 'ecr-repo-fb-submitter-workers' ]] && [[ $BUILD_WORKER == 'true' ]]; then
           echo "*******************************************************************"
           echo "Building submitter worker"
@@ -220,7 +228,7 @@ for ecr_credential in ${ecr_credentials[@]}; do
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
 
-        if [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]] && [[ $ecr_credential != 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]] && [[ $ecr_credential != 'ecr-repo-fb-publisher-worker' ]] && [[ $BUILD_WORKER != 'true' ]]; then
+        if [[ $ecr_credential != 'ecr-repo-fb-editor-workers' ]] && [[ $ecr_credential != 'ecr-repo-fb-submitter-workers' ]] && [[ $ecr_credential != 'ecr-repo-hmcts-complaints-formbuilder-adapter-worker' ]] && [[ $ecr_credential != 'ecr-repo-fb-publisher-worker' ]] && [[ $BUILD_WORKER != 'true' ]]; then
           build_and_push ${ECR_REPO_URL} ${environment_name} ${build_SHA}  ${dockerfile}
         fi
       fi


### PR DESCRIPTION
These changes are used with multiple changes to individual circle ci pipelines so that we no longer use long lived credentials to log in to aws in order to push ECR images.